### PR TITLE
Naming things, use "cratedb-prometheus-adapter"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 .idea
-crate_adapter
+cratedb-prometheus-adapter

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,18 @@ CHANGES for Prometheus CrateDB Adapter
 Unreleased
 ==========
 
+BREAKING CHANGES
+
+- This release changes the program name to ``cratedb-prometheus-adapter``
+  and the default prefix for exported metrics to ``cratedb_prometheus_adapter_``.
+  The latter can be reconfigured using the new ``-metrics.export.prefix`` option.
+
+Details:
+
 - Provide a default ``config.yml`` in the Docker image, which can be replaced
   by mounting a file on ``/etc/cratedb-prometheus-adapter/config.yml``.
+
+- Made Go 1.16 a minimum requirement.
 
 - Updated project to make use of `Go modules <https://golang.org/ref/mod>`_
   instead of Govendor.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ BREAKING CHANGES
   and the default prefix for exported metrics to ``cratedb_prometheus_adapter_``.
   The latter can be reconfigured using the new ``-metrics.export.prefix`` option.
 
-Details:
+CHANGES
+-------
 
 - Provide a default ``config.yml`` in the Docker image, which can be replaced
   by mounting a file on ``/etc/cratedb-prometheus-adapter/config.yml``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,18 @@ Unreleased
 ==========
 
 - Provide a default ``config.yml`` in the Docker image, which can be replaced
-  by mounting a file on ``/etc/crate_adapter/config.yml``.
+  by mounting a file on ``/etc/cratedb-prometheus-adapter/config.yml``.
 
 - Updated project to make use of `Go modules <https://golang.org/ref/mod>`_
   instead of Govendor.
+
+- Renamed the program to ``cratedb-prometheus-adapter``.
+
+- Renamed the exported metric prefix to ``cratedb_prometheus_adapter_``. It is
+  now, for example, ``cratedb_prometheus_adapter_write_latency_seconds``.
+  Attention: This is a breaking change with respect to your exported metric
+  names. In order to keep the former name, use
+  ``./cratedb-prometheus-adapter -metrics.export.prefix=crate_adapter_``.
 
 2019-03-06 0.2.1
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 ==========
 
 BREAKING CHANGES
+----------------
 
 - This release changes the program name to ``cratedb-prometheus-adapter``
   and the default prefix for exported metrics to ``cratedb_prometheus_adapter_``.

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -12,8 +12,8 @@ directory:
 
    $ mkdir -pv ${GOPATH}/src/github.com/crate
    $ cd ${GOPATH}/src/github.com/crate
-   $ git clone https://github.com/crate/crate_adapter.git
-   $ cd crate_adapter
+   $ git clone https://github.com/crate/cratedb-prometheus-adapter.git
+   $ cd cratedb-prometheus-adapter
 
 To simply run the adapter, invoke:
 
@@ -21,7 +21,7 @@ To simply run the adapter, invoke:
 
    $ go run server.go crate.go
 
-To build the ``crate_adapter`` executable, run:
+To build the ``cratedb-prometheus-adapter`` executable, run:
 
 .. code-block:: console
 
@@ -56,7 +56,7 @@ On the release branch:
 
 - Create a tag by running ``./devtools/create_tag.sh``
 
-On master:
+On branch "main":
 
 - Update the release notes to reflect the release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.16 as builder
-WORKDIR /go/src/github.com/crate/crate_adapter
-COPY . /go/src/github.com/crate/crate_adapter/
+WORKDIR /go/src/github.com/crate/cratedb-prometheus-adapter
+COPY . /go/src/github.com/crate/cratedb-prometheus-adapter/
 RUN CGO_ENABLED=0 GOOS=linux go build
 
 FROM alpine:3.13
 EXPOSE 9268
-COPY --from=builder /go/src/github.com/crate/crate_adapter/crate_adapter /usr/bin/crate_adapter
-WORKDIR /etc/crate_adapter
+COPY --from=builder /go/src/github.com/crate/cratedb-prometheus-adapter/cratedb-prometheus-adapter /usr/bin/cratedb-prometheus-adapter
+WORKDIR /etc/cratedb-prometheus-adapter
 COPY config.yml .
-ENTRYPOINT ["/usr/bin/crate_adapter"]
-CMD ["-config.file=/etc/crate_adapter/config.yml"]
+ENTRYPOINT ["/usr/bin/cratedb-prometheus-adapter"]
+CMD ["-config.file=/etc/cratedb-prometheus-adapter/config.yml"]

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ This is an adapter that accepts Prometheus remote read/write requests,
 and sends them to CrateDB. This allows using CrateDB as long term storage
 for Prometheus.
 
+Along the lines, the program also exports metrics about itself, using the
+``cratedb_prometheus_adapter_`` prefix.
+
 Requires CrateDB **3.1.0** or greater.
 
 Building from source
@@ -16,13 +19,13 @@ Building from source
 To build the CrateDB Prometheus Adapter from source, you need to have a working
 Go environment with **Golang version 1.16** installed.
 
-Use the ``go`` tool to download and install the ``crate_adapter`` executable
+Use the ``go`` tool to download and install the ``cratedb-prometheus-adapter`` executable
 into your ``GOPATH``:
 
 .. code-block:: console
 
-   $ go get github.com/crate/crate_adapter
-   $ cd $GOPATH/src/github.com/crate/crate_adapter
+   $ go get github.com/crate/cratedb-prometheus-adapter
+   $ cd $GOPATH/src/github.com/crate/cratedb-prometheus-adapter
 
 Alternatively, you can clone the repository and compile the binary:
 
@@ -30,8 +33,8 @@ Alternatively, you can clone the repository and compile the binary:
 
    $ mkdir -pv ${GOPATH}/src/github.com/crate
    $ cd ${GOPATH}/src/github.com/crate
-   $ git clone https://github.com/crate/crate_adapter.git
-   $ cd crate_adapter
+   $ git clone https://github.com/crate/cratedb-prometheus-adapter.git
+   $ cd cratedb-prometheus-adapter
    $ go build
 
 Usage
@@ -56,7 +59,7 @@ and create hourly, weekly,... partitions.
 
 Then run the adapter::
 
-  ./crate_adapter
+  ./cratedb-prometheus-adapter
 
 By default the adapter will listen on port ``9268``.
 This and more is configurable via command line flags, which you can see by passing the ``-h`` flag.
@@ -106,7 +109,7 @@ image.
 
 .. code-block:: console
 
-   $ docker build --rm --tag crate/crate-adapter .
+   $ docker build --rm --tag crate/cratedb-prometheus-adapter .
 
 When running the adapter inside Docker, you need to make sure that the running
 container has access to the CrateDB instance(s) which it should write to / read
@@ -117,41 +120,41 @@ To expose the ``/read``, ``/write`` and ``/metrics`` endpoints, the port
 
 .. code-block:: console
 
-   $ docker run --rm -ti -p 9268:9268 crate/crate-adapter
+   $ docker run --rm -ti -p 9268:9268 crate/cratedb-prometheus-adapter
 
 Since the default configuration would use ``localhost`` as CrateDB endpoint, a
 ``config.yml`` with the correct configuration needs to be mounted on
-``/etc/crate_adapter/config.yml``.
+``/etc/cratedb-prometheus-adapter/config.yml``.
 
 .. code-block:: console
 
-   $ docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/crate_adapter/config.yaml crate/crate-adapter
+   $ docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml crate/cratedb-prometheus-adapter
 
 Running with systemd
 ====================
 
-Copy `<config.yml>`_ to ``/etc/crate_adapter/config.yml`` and adjust as needed.
+Copy `<config.yml>`_ to ``/etc/cratedb-prometheus-adapter/config.yml`` and adjust as needed.
 
-Copy `<systemd/crate_adapter.service>`_ to ``/etc/systemd/system/crate_adapter.service`` or
-just link the service file by running: ``sudo systemctl link $(pwd)/crate_adapter.service``
+Copy `<systemd/cratedb-prometheus-adapter.service>`_ to ``/etc/systemd/system/cratedb-prometheus-adapter.service`` or
+just link the service file by running: ``sudo systemctl link $(pwd)/cratedb-prometheus-adapter.service``
 and run::
 
   systemctl daemon-reload
 
-Change flag-based configuration by changing the settings in ``/etc/default/crate_adapter``
-based on the `<systemd/crate_adapter.default>`_ template. After that you can::
+Change flag-based configuration by changing the settings in ``/etc/default/cratedb-prometheus-adapter``
+based on the `<systemd/cratedb-prometheus-adapter.default>`_ template. After that you can::
 
-  systemctl start crate_adapter
-  systemctl enable crate_adapter
+  systemctl start cratedb-prometheus-adapter
+  systemctl enable cratedb-prometheus-adapter
 
 
-.. |version| image:: https://img.shields.io/github/tag/crate/crate_adapter.svg
+.. |version| image:: https://img.shields.io/github/tag/crate/cratedb-prometheus-adapter.svg
     :alt: Version
-    :target: https://github.com/crate/crate_adapter
+    :target: https://github.com/crate/cratedb-prometheus-adapter
 
-.. |ci-tests| image:: https://github.com/crate/crate_adapter/workflows/Tests/badge.svg
+.. |ci-tests| image:: https://github.com/crate/cratedb-prometheus-adapter/workflows/Tests/badge.svg
     :alt: CI status
-    :target: https://github.com/crate/crate_adapter/actions?workflow=Tests
+    :target: https://github.com/crate/cratedb-prometheus-adapter/actions?workflow=Tests
 
 .. |license| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
     :alt: License: Apache 2.0

--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -53,7 +53,7 @@ git fetch origin > /dev/null
 BRANCH=`git branch | grep "^*" | cut -d " " -f 2`
 p_ok "Current branch is $BRANCH"
 
-# check if master == origin/master
+# check if main == origin/main
 LOCAL_COMMIT=`git show --format="%H" $BRANCH`
 ORIGIN_COMMIT=`git show --format="%H" origin/$BRANCH`
 
@@ -71,8 +71,8 @@ then
 fi
 
 # check if tag to create has already been created
-VERSION=`./crate_adapter -version`
-rm crate_adapter
+VERSION=`./cratedb-prometheus-adapter -version`
+rm cratedb-prometheus-adapter
 EXISTS=`git tag | grep $VERSION`
 if [ "$VERSION" == "$EXISTS" ]
 then

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crate/crate_adapter
+module github.com/crate/cratedb-prometheus-adapter
 
 go 1.16
 

--- a/server_test.go
+++ b/server_test.go
@@ -340,7 +340,9 @@ func TestExportedMetrics(t *testing.T) {
 	metrics, _ := prometheus.DefaultGatherer.Gather()
 	for _, metric := range metrics {
 		name := metric.GetName()
-		if !strings.HasPrefix(name, "cratedb_prometheus_adapter_") && !strings.HasPrefix(name, "go_") {
+		if !strings.HasPrefix(name, "cratedb_prometheus_adapter_") &&
+			!strings.HasPrefix(name, "go_") &&
+			!strings.HasPrefix(name, "process_") {
 			message := fmt.Sprintf("Exported metrics prefix does not match expectation for '%s'", name)
 			t.Fatal(message)
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"math"
 	"path/filepath"
 	"reflect"
@@ -331,4 +333,17 @@ func TestLoadConfig(t *testing.T) {
 			t.Errorf("%q: unexpected config contents;\n\nwant:\n\n%v\n\ngot:\n\n%v", test.file, test.config, conf)
 		}
 	}
+}
+
+func TestExportedMetrics(t *testing.T) {
+
+	metrics, _ := prometheus.DefaultGatherer.Gather()
+	for _, metric := range metrics {
+		name := metric.GetName()
+		if !strings.HasPrefix(name, "cratedb_prometheus_adapter_") && !strings.HasPrefix(name, "go_") {
+			message := fmt.Sprintf("Exported metrics prefix does not match expectation for '%s'", name)
+			t.Fatal(message)
+		}
+	}
+
 }

--- a/systemd/crate_adapter.default
+++ b/systemd/crate_adapter.default
@@ -1,1 +1,0 @@
-CRATE_ADAPTER_OPTS=-config.file=/etc/crate_adapter/config.yml -log.level=warn

--- a/systemd/cratedb-prometheus-adapter.default
+++ b/systemd/cratedb-prometheus-adapter.default
@@ -1,0 +1,1 @@
+CRATEDB_PROMETHEUS_ADAPTER_OPTS=-config.file=/etc/cratedb-prometheus-adapter/config.yml -log.level=warn

--- a/systemd/cratedb-prometheus-adapter.service
+++ b/systemd/cratedb-prometheus-adapter.service
@@ -2,13 +2,13 @@
 
 [Unit]
 Description=Prometheus adapter to write to CrateDB
-Documentation=https://github.com/crate/crate_adapter/
+Documentation=https://github.com/crate/cratedb-prometheus-adapter/
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/default/crate_adapter
+EnvironmentFile=-/etc/default/cratedb-prometheus-adapter
 User=prometheus
-ExecStart=/usr/bin/crate_adapter $CRATE_ADAPTER_OPTS
+ExecStart=/usr/bin/cratedb-prometheus-adapter $CRATEDB_PROMETHEUS_ADAPTER_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 LimitNOFILE=65536


### PR DESCRIPTION
Hi there,

as this codebase was getting some love by @chaudum recently (thanks a stack!), I decided to finally propose using a more appropriate name for this repository and its contents. I believe `crate_adapter` gives way too little context what it is all about. Before this will reach a 1.0.0, I believe it is a sensible thing to do.

This patch renames the program to be called `cratedb-prometheus-adapter`. Also, by default, it now uses `cratedb_prometheus_adapter_` as a prefix for the metrics it exports itself. However, this can be configured like `./cratedb-prometheus-adapter -metrics.export.prefix=crate_adapter_` to use the former metrics prefix.

With kind regards,
Andreas.
