### PR TITLE
Automatically release Docker images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+# https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md
+# https://github.com/crazy-max/ghaction-docker-meta
+# https://github.com/docker/build-push-action
+name: Release
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            crate/cratedb-prometheus-adapter
+            ghcr.io/crate/cratedb-prometheus-adapter
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule,pattern=nightly
+            type=ref,event=tag
+      -
+        name: Inspect meta
+        run: |
+          echo "Tags:      ${{ steps.meta.outputs.tags }}"
+          echo "Labels:    ${{ steps.meta.outputs.labels }}"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/crate/cratedb-prometheus-adapter
 COPY . /go/src/github.com/crate/cratedb-prometheus-adapter/
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.13
+FROM scratch
 EXPOSE 9268
 COPY --from=builder /go/src/github.com/crate/cratedb-prometheus-adapter/cratedb-prometheus-adapter /usr/bin/cratedb-prometheus-adapter
 WORKDIR /etc/cratedb-prometheus-adapter

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,12 @@ and create hourly, weekly,... partitions.
 
 Then run the adapter::
 
+  # When using the single binary
   ./cratedb-prometheus-adapter
+
+  # When using Docker
+  docker run -it --rm -publish=9268:9268 ghcr.io/crate/cratedb-prometheus-adapter:0.3.0
+
 
 By default the adapter will listen on port ``9268``.
 This and more is configurable via command line flags, which you can see by passing the ``-h`` flag.
@@ -101,8 +106,9 @@ Add the following to your ``prometheus.yml``:
 
 The adapter also exposes Prometheus metrics on ``/metrics``, and can be scraped in the usual fashion.
 
-Running with Docker
-===================
+
+Building the Docker image
+=========================
 
 The project contains a ``Dockerfile`` which can be used to build a Docker
 image.


### PR DESCRIPTION
Hi there,

this adds a recipe derived from [1] to the CI configuration. It should build and publish Docker images when there are tags pushed to the repository.

With kind regards,
Andreas.

[1] https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md