### PR TITLE
Rename toplevel configuration section name to "cratedb_endpoints"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,15 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 
+BREAKING CHANGES
+----------------
+
+- This release changes the toplevel configuration section name to ``cratedb_endpoints``.
+  It is an aftermath of the "naming things" refactorings happening in 0.3.0.
+
+CHANGES
+-------
+
 - Improve network behaviour: Adjust TCP timeout and keepalive settings to
   mitigate problems that can occur when the adapter in connecting to CrateDB
   via a load balancer that may drop idle connections in-transparently, such as

--- a/README.rst
+++ b/README.rst
@@ -73,8 +73,8 @@ The CrateDB endpoints are provided in a configuration file, which defaults to
 ``config.yml`` (``-config.file`` flag). The included example configuration file forwards
 samples to a CrateDB running on ``localhost`` on port ``5432``.
 
-Adapter Crate Endpoint Configuration
-====================================
+CrateDB Adapter Endpoint Configuration
+======================================
 
 The CrateDB endpoints that the adapter writes to are configured in a YAML-based configuration
 file provided by the ``-config.file`` flag. If multiple endpoints are listed, the adapter will
@@ -82,7 +82,7 @@ load-balance between them. The options (for one example endpoint) are as below:
 
 .. code-block:: yaml
 
-  crate_endpoints:
+  cratedb_endpoints:
   - host: "localhost"         # Host to connect to (default: "localhost").
     port: 5432                # Port to connect to (default: 5432).
     user: "crate"             # Username to use (default: "crate")

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-crate_endpoints:
+cratedb_endpoints:
 - host: "localhost"         # Host to connect to (default: "localhost").
   port: 5432                # Port to connect to (default: 5432).
   user: "crate"             # Username to use (default: "crate")

--- a/fixtures/config_good.yml
+++ b/fixtures/config_good.yml
@@ -1,4 +1,4 @@
-crate_endpoints:
+cratedb_endpoints:
 - host: "host1"
   port: 1
   user: "user1"

--- a/fixtures/config_no_endpoints.yml
+++ b/fixtures/config_no_endpoints.yml
@@ -1,1 +1,1 @@
-crate_endpoints:
+cratedb_endpoints:

--- a/fixtures/config_unknown_fields.yml
+++ b/fixtures/config_unknown_fields.yml
@@ -1,4 +1,4 @@
-crate_endpoints:
+cratedb_endpoints:
 - host: "host1"
   port: 1
   user: "user1"

--- a/server.go
+++ b/server.go
@@ -349,7 +349,7 @@ type endpointConfig struct {
 }
 
 type config struct {
-	Endpoints []endpointConfig `yaml:"crate_endpoints"`
+	Endpoints []endpointConfig `yaml:"cratedb_endpoints"`
 }
 
 func (c *config) toString() string {


### PR DESCRIPTION
Hi again,

this accompanies the "naming things" patch coming from #40.

With kind regards,
Andreas.
