### PR TITLE
Improve documentation

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -1,3 +1,6 @@
+.. highlight:: bash
+
+
 ===============
 Developer Guide
 ===============
@@ -9,53 +12,33 @@ Building from source
 To build the CrateDB Prometheus Adapter from source, you need to have a working
 Go environment with **Golang version 1.16** installed.
 
-Use the ``go`` tool to download and install the ``cratedb-prometheus-adapter`` executable
-into your ``GOPATH``:
-
-.. code-block:: console
+Use the ``go`` tool to download and install the ``cratedb-prometheus-adapter``
+executable into your ``GOPATH``::
 
    go get github.com/crate/cratedb-prometheus-adapter
-   cd $GOPATH/src/github.com/crate/cratedb-prometheus-adapter
-
-Alternatively, you can clone the repository and compile the binary:
-
-.. code-block:: console
-
-   mkdir -pv ${GOPATH}/src/github.com/crate
-   cd ${GOPATH}/src/github.com/crate
-   git clone https://github.com/crate/cratedb-prometheus-adapter.git
-   cd cratedb-prometheus-adapter
-   go build
 
 
-Setup
-=====
+Setup sandbox
+=============
 
+For working on the source code, it is advised to setup a development sandbox.
 To start things off, clone the repository and change into the newly checked out
-directory:
-
-.. code-block:: console
+directory::
 
    mkdir -pv ${GOPATH}/src/github.com/crate
    cd ${GOPATH}/src/github.com/crate
    git clone https://github.com/crate/cratedb-prometheus-adapter.git
    cd cratedb-prometheus-adapter
 
-To simply run the adapter, invoke:
-
-.. code-block:: console
+To simply run the adapter, invoke::
 
    go run .
 
-To build the ``cratedb-prometheus-adapter`` executable, run:
-
-.. code-block:: console
+To build the ``cratedb-prometheus-adapter`` executable, run::
 
    go build
 
-To run the test suite, execute:
-
-.. code-block:: console
+To run the test suite, execute::
 
    go test
 
@@ -101,9 +84,7 @@ Building the Docker image
 =========================
 
 The project contains a ``Dockerfile`` which can be used to build a Docker
-image.
-
-.. code-block:: console
+image::
 
    docker build --rm --tag crate/cratedb-prometheus-adapter .
 
@@ -112,16 +93,12 @@ container has access to the CrateDB instance(s) which it should write to / read
 from.
 
 To expose the ``/read``, ``/write`` and ``/metrics`` endpoints, the port
-``9268`` must be published.
-
-.. code-block:: console
+``9268`` must be published::
 
    docker run --rm -ti -p 9268:9268 crate/cratedb-prometheus-adapter
 
 Since the default configuration would use ``localhost`` as CrateDB endpoint, a
 ``config.yml`` with the correct configuration needs to be mounted on
-``/etc/cratedb-prometheus-adapter/config.yml``.
-
-.. code-block:: console
+``/etc/cratedb-prometheus-adapter/config.yml``::
 
    docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml crate/cratedb-prometheus-adapter

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -2,6 +2,32 @@
 Developer Guide
 ===============
 
+
+Building from source
+====================
+
+To build the CrateDB Prometheus Adapter from source, you need to have a working
+Go environment with **Golang version 1.16** installed.
+
+Use the ``go`` tool to download and install the ``cratedb-prometheus-adapter`` executable
+into your ``GOPATH``:
+
+.. code-block:: console
+
+   go get github.com/crate/cratedb-prometheus-adapter
+   cd $GOPATH/src/github.com/crate/cratedb-prometheus-adapter
+
+Alternatively, you can clone the repository and compile the binary:
+
+.. code-block:: console
+
+   mkdir -pv ${GOPATH}/src/github.com/crate
+   cd ${GOPATH}/src/github.com/crate
+   git clone https://github.com/crate/cratedb-prometheus-adapter.git
+   cd cratedb-prometheus-adapter
+   go build
+
+
 Setup
 =====
 
@@ -10,28 +36,29 @@ directory:
 
 .. code-block:: console
 
-   $ mkdir -pv ${GOPATH}/src/github.com/crate
-   $ cd ${GOPATH}/src/github.com/crate
-   $ git clone https://github.com/crate/cratedb-prometheus-adapter.git
-   $ cd cratedb-prometheus-adapter
+   mkdir -pv ${GOPATH}/src/github.com/crate
+   cd ${GOPATH}/src/github.com/crate
+   git clone https://github.com/crate/cratedb-prometheus-adapter.git
+   cd cratedb-prometheus-adapter
 
 To simply run the adapter, invoke:
 
 .. code-block:: console
 
-   $ go run server.go crate.go
+   go run .
 
 To build the ``cratedb-prometheus-adapter`` executable, run:
 
 .. code-block:: console
 
-   $ go build
+   go build
 
 To run the test suite, execute:
 
 .. code-block:: console
 
-   $ go test
+   go test
+
 
 Preparing a Release
 ===================
@@ -68,3 +95,33 @@ Next:
 - Trigger the build/release script on `Jenkins CI`_ for the newly created tag
 
 .. _Jenkins CI: https://jenkins.crate.io
+
+
+Building the Docker image
+=========================
+
+The project contains a ``Dockerfile`` which can be used to build a Docker
+image.
+
+.. code-block:: console
+
+   docker build --rm --tag crate/cratedb-prometheus-adapter .
+
+When running the adapter inside Docker, you need to make sure that the running
+container has access to the CrateDB instance(s) which it should write to / read
+from.
+
+To expose the ``/read``, ``/write`` and ``/metrics`` endpoints, the port
+``9268`` must be published.
+
+.. code-block:: console
+
+   docker run --rm -ti -p 9268:9268 crate/cratedb-prometheus-adapter
+
+Since the default configuration would use ``localhost`` as CrateDB endpoint, a
+``config.yml`` with the correct configuration needs to be mounted on
+``/etc/cratedb-prometheus-adapter/config.yml``.
+
+.. code-block:: console
+
+   docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml crate/cratedb-prometheus-adapter

--- a/README.rst
+++ b/README.rst
@@ -11,31 +11,19 @@ for Prometheus.
 Along the lines, the program also exports metrics about itself, using the
 ``cratedb_prometheus_adapter_`` prefix.
 
-Requires CrateDB **3.1.0** or greater.
 
-Building from source
-====================
+Setup
+=====
 
-To build the CrateDB Prometheus Adapter from source, you need to have a working
-Go environment with **Golang version 1.16** installed.
+The CrateDB Prometheus Adapter is offered in two different distribution
+variants. You can choose freely which fits your needs best.
 
-Use the ``go`` tool to download and install the ``cratedb-prometheus-adapter`` executable
-into your ``GOPATH``:
+- `Native release archives`_ for Linux, Darwin and Windows platforms.
+- Public Docker image `ghcr.io/crate/cratedb-prometheus-adapter`_.
 
-.. code-block:: console
+.. _Native release archives: https://cdn.crate.io/downloads/dist/prometheus/
+.. _ghcr.io/crate/cratedb-prometheus-adapter: https://ghcr.io/crate/cratedb-prometheus-adapter
 
-   $ go get github.com/crate/cratedb-prometheus-adapter
-   $ cd $GOPATH/src/github.com/crate/cratedb-prometheus-adapter
-
-Alternatively, you can clone the repository and compile the binary:
-
-.. code-block:: console
-
-   $ mkdir -pv ${GOPATH}/src/github.com/crate
-   $ cd ${GOPATH}/src/github.com/crate
-   $ git clone https://github.com/crate/cratedb-prometheus-adapter.git
-   $ cd cratedb-prometheus-adapter
-   $ go build
 
 Usage
 =====
@@ -55,30 +43,34 @@ Create the following table in your CrateDB database:
     ) PARTITIONED BY ("day__generated");
 
 Depending on data volume and retention you might want to optimize your partitioning scheme
-and create hourly, weekly,... partitions.
+and create hourly, weekly, ... partitions.
 
 Then run the adapter::
 
-  # When using the single binary
-  ./cratedb-prometheus-adapter
+    # When using the single binary
+    ./cratedb-prometheus-adapter
 
-  # When using Docker
-  docker run -it --rm --publish=9268:9268 ghcr.io/crate/cratedb-prometheus-adapter
+    # When using Docker
+    docker run -it --rm --publish=9268:9268 ghcr.io/crate/cratedb-prometheus-adapter
 
-
-By default the adapter will listen on port ``9268``.
-This and more is configurable via command line flags, which you can see by passing the ``-h`` flag.
+By default the adapter will listen on port ``9268`` and will use a built-in
+configuration as outlined in the next section.
+This and more is configurable via command line flags, which you can see by
+passing the ``-h`` flag.
 
 The CrateDB endpoints are provided in a configuration file, which defaults to
-``config.yml`` (``-config.file`` flag). The included example configuration file forwards
-samples to a CrateDB running on ``localhost`` on port ``5432``.
+``config.yml`` (``-config.file`` flag). The included example configuration file
+forwards samples to a CrateDB running on ``localhost`` on port ``5432``.
 
 CrateDB Adapter Endpoint Configuration
 ======================================
 
-The CrateDB endpoints that the adapter writes to are configured in a YAML-based configuration
-file provided by the ``-config.file`` flag. If multiple endpoints are listed, the adapter will
-load-balance between them. The options (for one example endpoint) are as below:
+The path to the YAML-based configuration file can be provided by using the
+``-config.file`` command line option.
+The settings describe the CrateDB endpoints the adapter will write to.
+
+If multiple endpoints are listed, the adapter will load-balance between them.
+The options (with one example endpoint) are as below:
 
 .. code-block:: yaml
 
@@ -96,7 +88,8 @@ load-balance between them. The options (for one example endpoint) are as below:
 Prometheus Configuration
 ========================
 
-Add the following to your ``prometheus.yml``:
+In order to forward write and read requests to the CrateDB adapter, adjust your
+``prometheus.yml`` like:
 
 .. code-block:: yaml
 
@@ -105,40 +98,15 @@ Add the following to your ``prometheus.yml``:
   remote_read:
      - url: http://localhost:9268/read
 
-The adapter also exposes Prometheus metrics on ``/metrics``, and can be scraped in the usual fashion.
+The adapter also exposes Prometheus metrics on ``/metrics``, which can be scraped in the usual way.
 
 
-Building the Docker image
-=========================
+Running as service
+==================
 
-The project contains a ``Dockerfile`` which can be used to build a Docker
-image.
-
-.. code-block:: console
-
-   $ docker build --rm --tag crate/cratedb-prometheus-adapter .
-
-When running the adapter inside Docker, you need to make sure that the running
-container has access to the CrateDB instance(s) which it should write to / read
-from.
-
-To expose the ``/read``, ``/write`` and ``/metrics`` endpoints, the port
-``9268`` must be published.
-
-.. code-block:: console
-
-   $ docker run --rm -ti -p 9268:9268 crate/cratedb-prometheus-adapter
-
-Since the default configuration would use ``localhost`` as CrateDB endpoint, a
-``config.yml`` with the correct configuration needs to be mounted on
-``/etc/cratedb-prometheus-adapter/config.yml``.
-
-.. code-block:: console
-
-   $ docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml crate/cratedb-prometheus-adapter
-
-Running with systemd
-====================
+In order to run ``cratedb-prometheus-adapter`` as a system service on Linux,
+the repository provides configuration files to configure the program as a
+``systemd`` service unit. This section outlines how to apply that configuration.
 
 Copy `<config.yml>`_ to ``/etc/cratedb-prometheus-adapter/config.yml`` and adjust as needed.
 
@@ -146,13 +114,13 @@ Copy `<systemd/cratedb-prometheus-adapter.service>`_ to ``/etc/systemd/system/cr
 just link the service file by running: ``sudo systemctl link $(pwd)/cratedb-prometheus-adapter.service``
 and run::
 
-  systemctl daemon-reload
+    systemctl daemon-reload
 
 Change flag-based configuration by changing the settings in ``/etc/default/cratedb-prometheus-adapter``
 based on the `<systemd/cratedb-prometheus-adapter.default>`_ template. After that you can::
 
-  systemctl start cratedb-prometheus-adapter
-  systemctl enable cratedb-prometheus-adapter
+    systemctl start cratedb-prometheus-adapter
+    systemctl enable cratedb-prometheus-adapter
 
 
 .. |version| image:: https://img.shields.io/github/tag/crate/cratedb-prometheus-adapter.svg

--- a/systemd/cratedb-prometheus-adapter.default
+++ b/systemd/cratedb-prometheus-adapter.default
@@ -1,1 +1,1 @@
-CRATEDB_PROMETHEUS_ADAPTER_OPTS=-config.file=/etc/cratedb-prometheus-adapter/config.yml -log.level=warn
+CRATEDB_PROMETHEUS_ADAPTER_OPTS=-config.file=/etc/cratedb-prometheus-adapter/config.yml


### PR DESCRIPTION
Hi there,

accompanying our previous improvements, this finally gives some love to the documentation (README file).

It moves all developer-related information to the "DEVELOP.rst" file and better outlines how to use the release archives and images within "README.rst".

With kind regards,
Andreas.
