### PR TITLE
CI: Improve recipes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
   push:
     tags:
       - '*.*.*'
+  workflow_dispatch:
 
 env:
   GHCR_IMAGE_NAME: crate/cratedb-prometheus-adapter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
Just two minor improvemnts.

- Cancel previous jobs when pushing to the same branch consecutively
- Permit running the "Release" job manually from the UI