### PR TITLE
CI: Don't push image to ghcr.io when "Release" job runs interactively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
Aims to fix running the "Release" job interactively [^1]. Now, it succeeded at [^2], by omitting the "push" step in this case.

[^1]: https://github.com/crate/cratedb-prometheus-adapter/actions/runs/3940882765/jobs/6742554727#step:10:136
[^2]: https://github.com/crate/cratedb-prometheus-adapter/actions/runs/3940965430/jobs/6742744601