### PR TITLE
Improve (first-time) invocation convenience

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
 - Add command line option ``-config.make`` to print a blueprint configuration
   file to stdout.
 
+- Add program version to startup log message
+
 
 2021-05-04 0.4.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Unreleased
 
 - Update dependency packages across the board to their latest or minor patch releases.
 
+- Accept invoking the program without default configuration file ``config.yml``.
+  In this case, the program will fall back to the builtin defaults, essentially
+  connecting to ``localhost:5432`` with username ``crate``.
+
 
 2021-05-04 0.4.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
   In this case, the program will fall back to the builtin defaults, essentially
   connecting to ``localhost:5432`` with username ``crate``.
 
+- Add command line option ``-config.make`` to print a blueprint configuration
+  file to stdout.
+
 
 2021-05-04 0.4.0
 ================

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -40,7 +40,7 @@ To build the ``cratedb-prometheus-adapter`` executable, run::
 
 To run the test suite, execute::
 
-   go test
+   go test -v
 
 
 Maintaining dependencies

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. highlights:: sh
+
 ==========================
 CrateDB Prometheus Adapter
 ==========================
@@ -45,7 +47,7 @@ Create the following table in your CrateDB database:
 Depending on data volume and retention you might want to optimize your partitioning scheme
 and create hourly, weekly, ... partitions.
 
-Then run the adapter::
+Then, run the adapter::
 
     # When using the single binary
     ./cratedb-prometheus-adapter
@@ -53,21 +55,22 @@ Then run the adapter::
     # When using Docker
     docker run -it --rm --publish=9268:9268 ghcr.io/crate/cratedb-prometheus-adapter
 
-By default the adapter will listen on port ``9268`` and will use a built-in
-configuration as outlined in the next section.
-This and more is configurable via command line flags, which you can see by
-passing the ``-h`` flag.
+By default, the adapter will listen on port ``9268`` and will use a built-in
+default configuration. More details how to individually configure it are
+outlined within the next section.
 
-The CrateDB endpoints are provided in a configuration file, which defaults to
-``config.yml`` (``-config.file`` flag). The included example configuration file
-forwards samples to a CrateDB running on ``localhost`` on port ``5432``.
+To display all available command line options and flags, use the ``-h`` flag.
 
 CrateDB Adapter Endpoint Configuration
 ======================================
 
-The path to the YAML-based configuration file can be provided by using the
-``-config.file`` command line option.
-The settings describe the CrateDB endpoints the adapter will write to.
+To configure the CrateDB endpoint(s) the adapter will write to, the path to the
+YAML-based configuration file can be provided by using the ``-config.file``
+command line option, its default value is ``config.yml``.
+
+To create a blueprint configuration file, run::
+
+    ./cratedb-prometheus-adapter -config.make > config.yml
 
 If multiple endpoints are listed, the adapter will load-balance between them.
 The options (with one example endpoint) are as below:

--- a/server.go
+++ b/server.go
@@ -362,12 +362,16 @@ func (c *config) toString() string {
 
 func loadConfig(filename string) (*config, error) {
 	content, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("error reading configuration file: %v", err)
-	}
 	conf := &config{}
-	if err = yaml.UnmarshalStrict(content, conf); err != nil {
-		return nil, fmt.Errorf("error unmarshaling YAML: %v", err)
+	if err != nil {
+		log.Warnf("No configuration file %q: %v", *configFile, err)
+		log.Infof("Falling back to default configuration")
+		item := endpointConfig{}
+		conf.Endpoints = []endpointConfig{item}
+	} else {
+		if err = yaml.UnmarshalStrict(content, conf); err != nil {
+			return nil, fmt.Errorf("error unmarshaling YAML: %v", err)
+		}
 	}
 
 	if len(conf.Endpoints) == 0 {
@@ -403,7 +407,7 @@ func main() {
 
 	conf, err := loadConfig(*configFile)
 	if err != nil {
-		log.Fatalf("Error loading configuration file %q: %v", *configFile, err)
+		log.Fatalf("Error loading configuration %q: %v", *configFile, err)
 	}
 
 	subscriber := sd.FixedEndpointer{}

--- a/server.go
+++ b/server.go
@@ -447,7 +447,7 @@ func main() {
 	http.HandleFunc("/write", ca.handleWrite)
 	http.HandleFunc("/read", ca.handleRead)
 	http.Handle("/metrics", promhttp.Handler())
-	log.Info("Starting CrateDB Prometheus Adapter")
+	log.Infof("Starting CrateDB Prometheus Adapter %v", version)
 	log.With("address", *listenAddress).Info("Listening ...")
 	log.With("endpoints", conf.toString()).Info("Connecting ...")
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))

--- a/server.go
+++ b/server.go
@@ -31,6 +31,7 @@ var (
 	listenAddress       = flag.String("web.listen-address", ":9268", "Address to listen on for Prometheus requests.")
 	configFile          = flag.String("config.file", "config.yml", "Path to the CrateDB endpoints configuration file.")
 	metricsExportPrefix = flag.String("metrics.export.prefix", "cratedb_prometheus_adapter_", "Prefix for exported CrateDB metrics.")
+	makeConfig          = flag.Bool("config.make", false, "Print configuration file blueprint to stdout.")
 	printVersion        = flag.Bool("version", false, "Print version information.")
 
 	writeDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -402,6 +403,19 @@ func main() {
 
 	if *printVersion {
 		fmt.Println(version)
+		return
+	}
+
+	if *makeConfig {
+		blueprint := &config{}
+		blueprint, err := loadConfig("")
+		item := endpointConfig{}
+		blueprint.Endpoints = []endpointConfig{item}
+		d, err := yaml.Marshal(&blueprint)
+		if err != nil {
+			log.Fatalf("error: %v", err)
+		}
+		fmt.Printf(string(d))
 		return
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -359,3 +359,27 @@ func TestExportedMetrics(t *testing.T) {
 	}
 
 }
+
+func TestBuiltinConfig(t *testing.T) {
+
+	referenceConfig := &config{
+		Endpoints: []endpointConfig{
+			{
+				Host:             "localhost",
+				Port:             5432,
+				User:             "crate",
+				Password:         "",
+				Schema:           "",
+				ConnectTimeout:   10,
+				MaxConnections:   5,
+				EnableTLS:        false,
+				AllowInsecureTLS: false,
+			},
+		},
+	}
+
+	builtinConfig, _ := loadConfig("")
+	if !reflect.DeepEqual(referenceConfig, builtinConfig) {
+		t.Errorf("unexpected config contents;\n\nwant:\n\n%v\n\ngot:\n\n%v", referenceConfig, builtinConfig)
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp/syntax"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -303,14 +302,22 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			file:       filepath.Join("fixtures", "config_missing_file.yml"),
-			shouldFail: true,
-			errContains: func(os string) string {
-				if os == "windows" {
-					return "The system cannot find the file specified"
-				} else {
-					return "no such file or directory"
-				}
-			}(runtime.GOOS),
+			shouldFail: false,
+			config: &config{
+				Endpoints: []endpointConfig{
+					{
+						Host:             "localhost",
+						Port:             5432,
+						User:             "crate",
+						Password:         "",
+						Schema:           "",
+						ConnectTimeout:   10,
+						MaxConnections:   5,
+						EnableTLS:        false,
+						AllowInsecureTLS: false,
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Hi there,

this patch aims to address GH-49. It implements three things.

- Accept invocation without default configuration file `config.yml`: When running `./cratedb-prometheus-adapter`, and there is no `config.yml` file in the working directory, the built-in default settings will be used, see https://github.com/crate/cratedb-prometheus-adapter/blob/75811a33de7dd823cc458365b7f2f2bd234b5c9c/server.go#L376-L392
- Add command line option `-config.make` to print a blueprint configuration file to stdout. It can be used like
  ```
  ./cratedb-prometheus-adapter -config.make > config.yml
  ```
- Add program version to startup log message

With kind regards,
Andreas.

/cc @chaudum 