### PR TITLE
Fix invocation behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 
+BREAKING CHANGES
+----------------
+
+- This release removes the default value for the ``-config.file`` command line
+  option, which was ``config.yml``. When the option is omitted, the service
+  will use the built-in settings, connecting to CrateDB on ``localhost:5432``.
+
+CHANGES
+-------
+
 - Add support for Go 1.18 and 1.19, drop support for previous releases.
 
 - Update dependency packages across the board to their latest or minor patch releases.

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -34,6 +34,10 @@ To simply run the adapter, invoke::
 
    go run .
 
+To print a default configuration to stdout, use::
+
+   go run . -config.make
+
 To build the ``cratedb-prometheus-adapter`` executable, run::
 
    go build

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ CrateDB adapter endpoint configuration
 
 To configure the CrateDB endpoint(s) the adapter will write to, the path to the
 YAML-based configuration file can be provided by using the ``-config.file``
-command line option, its default value is ``config.yml``.
+command line option.
 
 To create a blueprint configuration file, run::
 

--- a/server.go
+++ b/server.go
@@ -361,6 +361,14 @@ func (c *config) toString() string {
 	return strings.Join(ep, ",")
 }
 
+func (c *config) toYaml() string {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		log.Fatalf("Serialization to YAML failed: %v", err)
+	}
+	return string(data)
+}
+
 func loadConfig(filename string) (*config, error) {
 	content, err := ioutil.ReadFile(filename)
 	conf := &config{}
@@ -398,6 +406,11 @@ func loadConfig(filename string) (*config, error) {
 	return conf, nil
 }
 
+func builtinConfig() *config {
+	blueprint, _ := loadConfig("")
+	return blueprint
+}
+
 func main() {
 	flag.Parse()
 
@@ -407,15 +420,7 @@ func main() {
 	}
 
 	if *makeConfig {
-		blueprint := &config{}
-		blueprint, err := loadConfig("")
-		item := endpointConfig{}
-		blueprint.Endpoints = []endpointConfig{item}
-		d, err := yaml.Marshal(&blueprint)
-		if err != nil {
-			log.Fatalf("error: %v", err)
-		}
-		fmt.Printf(string(d))
+		fmt.Println(builtinConfig().toYaml())
 		return
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -378,7 +378,7 @@ func TestBuiltinConfig(t *testing.T) {
 		},
 	}
 
-	builtinConfig, _ := loadConfig("")
+	builtinConfig := builtinConfig()
 	if !reflect.DeepEqual(referenceConfig, builtinConfig) {
 		t.Errorf("unexpected config contents;\n\nwant:\n\n%v\n\ngot:\n\n%v", referenceConfig, builtinConfig)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp/syntax"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -302,22 +303,14 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			file:       filepath.Join("fixtures", "config_missing_file.yml"),
-			shouldFail: false,
-			config: &config{
-				Endpoints: []endpointConfig{
-					{
-						Host:             "localhost",
-						Port:             5432,
-						User:             "crate",
-						Password:         "",
-						Schema:           "",
-						ConnectTimeout:   10,
-						MaxConnections:   5,
-						EnableTLS:        false,
-						AllowInsecureTLS: false,
-					},
-				},
-			},
+			shouldFail: true,
+			errContains: func(os string) string {
+				if os == "windows" {
+					return "The system cannot find the file specified"
+				} else {
+					return "no such file or directory"
+				}
+			}(runtime.GOOS),
 		},
 	}
 


### PR DESCRIPTION
Hi again,

GH-59 was not solid enough.

1. It introduced a flaw that the program stopped failing when `-config.path` pointed to a non-existing path, and also used the built-in settings instead. This is wrong, the program should croak in this case.

2. Also, `-config.make` did not work as intended yet. It printed an _empty_ configuration, instead of the built-in default settings.
    ```
    $ docker run -it --rm --publish=9268:9268 ghcr.io/crate/cratedb-prometheus-adapter:nightly -config.make
    WARN[0000] No configuration file "config.yml": open : no such file or directory  source="server.go:368"
    INFO[0000] Falling back to default configuration         source="server.go:369"
    cratedb_endpoints:
    - host: ""
      port: 0
      user: ""
      password: ""
      schema: ""
      enable_tls: false
      allow_insecure_tls: false
      connect_timeout: 0
      max_connections: 0
    ```

With kind regards,
Andreas.
