### PR TITLE
Maintenance: Update Go versions and CI configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ 1.18.x, 1.19.x ]
+        go-version: [ 1.20.x, 1.21.x ]
       fail-fast: true
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,12 @@ name: Tests
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  pull_request: ~
+
+  # Allow job to be triggered manually.
   workflow_dispatch:
 
+# Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 
+- Add support for Go 1.20 and 1.21, drop support for previous releases.
+
 BREAKING CHANGES
 ----------------
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crate/cratedb-prometheus-adapter
 
-go 1.18
+go 1.20
 
 require (
 	github.com/go-kit/kit v0.9.0


### PR DESCRIPTION
## About

- Add support for Go 1.20 and 1.21, drop support for previous releases.
  Go 1.18 and 1.19 are end-of-life, see https://endoflife.date/go.
- CI: Support running software tests on stacked pull requests.
- CI: Also check GitHub Action dependencies.
- CI: Update to actions/setup-go@v4.
