### PR TITLE
Use DSN-style connection strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
 - Use a different connection pool for read vs. write operations.
   The corresponding settings to configure the maximum pool sizes
   are ``read_pool_size_max`` and ``write_pool_size_max``.
+- Use a DSN-style connection string for talking to pgx5
 
 BREAKING CHANGES
 ----------------

--- a/crate.go
+++ b/crate.go
@@ -66,13 +66,9 @@ func newCrateEndpoint(ep *endpointConfig) *crateEndpoint {
 	//
 	//   # Example URL
 	//   postgres://jack:secret@pg.example.com:5432/mydb?sslmode=verify-ca
-	connectionString := fmt.Sprintf(
-		"postgres://%s:%s@%s:%v/%s?connect_timeout=%v",
-		ep.User, ep.Password, ep.Host, ep.Port, ep.Schema, ep.ConnectTimeout)
-	if ep.MaxConnections != 0 {
-		connectionString += fmt.Sprintf("&pool_max_conns=%v", ep.MaxConnections)
-	}
-	poolConf, err := pgxpool.ParseConfig(connectionString)
+
+	// Create configuration object from DSN-style connection string.
+	poolConf, err := pgxpool.ParseConfig(ep.toDSN())
 	if err != nil {
 		return nil
 	}

--- a/crate_test.go
+++ b/crate_test.go
@@ -12,9 +12,11 @@ var CPU_COUNT = int32(runtime.NumCPU())
 
 func TestNewCrateEndpoint(t *testing.T) {
 	conf := builtinConfig()
+	conf.Endpoints[0].Password = "foobar+&%"
+	conf.Endpoints[0].Schema = "testdrive"
 	endpoint := newCrateEndpoint(&conf.Endpoints[0])
 	require.Equal(t,
-		"postgres://crate:@localhost:5432/?connect_timeout=10",
+		"host=localhost port=5432 user=crate password=foobar+&% database=testdrive connect_timeout=10",
 		endpoint.poolConf.ConnString(),
 	)
 	require.GreaterOrEqual(t, endpoint.poolConf.MaxConns, CPU_COUNT)
@@ -90,7 +92,7 @@ func TestPoolsDefault(t *testing.T) {
 	endpoint.createPools(ctx)
 	require.IsType(t, &pgxpool.Pool{}, endpoint.readPool)
 	require.Equal(t,
-		"postgres://crate:@localhost:5432/?connect_timeout=10",
+		"host=localhost port=5432 user=crate connect_timeout=10",
 		endpoint.poolConf.ConnString(),
 	)
 	require.GreaterOrEqual(t, endpoint.readPool.Config().MaxConns, CPU_COUNT)
@@ -108,7 +110,7 @@ func TestPoolsWithMaxConnections(t *testing.T) {
 	endpoint.createPools(ctx)
 	require.IsType(t, &pgxpool.Pool{}, endpoint.readPool)
 	require.Equal(t,
-		"postgres://crate:@localhost:5432/?connect_timeout=10&pool_max_conns=42",
+		"host=localhost port=5432 user=crate connect_timeout=10 pool_max_conns=42",
 		endpoint.poolConf.ConnString(),
 	)
 	require.Equal(t, int32(42), endpoint.readPool.Config().MaxConns)
@@ -127,7 +129,7 @@ func TestPoolsWithIndividualPoolSizes(t *testing.T) {
 	endpoint.createPools(ctx)
 	require.IsType(t, &pgxpool.Pool{}, endpoint.readPool)
 	require.Equal(t,
-		"postgres://crate:@localhost:5432/?connect_timeout=10",
+		"host=localhost port=5432 user=crate connect_timeout=10",
 		endpoint.poolConf.ConnString(),
 	)
 	require.Equal(t, int32(11), endpoint.readPool.Config().MaxConns)
@@ -146,7 +148,7 @@ func TestPoolsWithMaxConnectionsAndIndividualPoolSizes(t *testing.T) {
 	endpoint.createPools(ctx)
 	require.IsType(t, &pgxpool.Pool{}, endpoint.readPool)
 	require.Equal(t,
-		"postgres://crate:@localhost:5432/?connect_timeout=10&pool_max_conns=5",
+		"host=localhost port=5432 user=crate connect_timeout=10 pool_max_conns=5",
 		endpoint.poolConf.ConnString(),
 	)
 	require.Equal(t, int32(40), endpoint.readPool.Config().MaxConns)

--- a/server.go
+++ b/server.go
@@ -353,6 +353,33 @@ type endpointConfig struct {
 	AllowInsecureTLS bool   `yaml:"allow_insecure_tls"`
 }
 
+func (ep *endpointConfig) toDSN() string {
+	// Convert endpointConfig data to libpq-compatible DSN-style connection string.
+	var params []string
+	if ep.Host != "" {
+		params = append(params, fmt.Sprintf("host=%s", ep.Host))
+	}
+	if ep.Port != 0 {
+		params = append(params, fmt.Sprintf("port=%v", ep.Port))
+	}
+	if ep.User != "" {
+		params = append(params, fmt.Sprintf("user=%s", ep.User))
+	}
+	if ep.Password != "" {
+		params = append(params, fmt.Sprintf("password=%s", ep.Password))
+	}
+	if ep.Schema != "" {
+		params = append(params, fmt.Sprintf("database=%s", ep.Schema))
+	}
+	if ep.ConnectTimeout != 0 {
+		params = append(params, fmt.Sprintf("connect_timeout=%v", ep.ConnectTimeout))
+	}
+	if ep.MaxConnections != 0 {
+		params = append(params, fmt.Sprintf("pool_max_conns=%v", ep.MaxConnections))
+	}
+	return strings.Join(params, " ")
+}
+
 type config struct {
 	Endpoints []endpointConfig `yaml:"cratedb_endpoints"`
 }


### PR DESCRIPTION
## About

At https://github.com/crate/cratedb-prometheus-adapter/pull/77#discussion_r1311560136, @hlcianfagna reported that it may not be a good idea to converge to connection strings in URL format. This patch switches over to use DSN-style connection strings.
