### PR TITLE
Update Protocol Buffers libraries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
   are ``read_pool_size_max`` and ``write_pool_size_max``.
 - Use a DSN-style connection string for talking to pgx5
 - Update Prometheus libraries (client: 1.16, server: 2.46)
+- Update Protocol Buffers libraries (google.golang.org/protobuf 1.31)
 
 BREAKING CHANGES
 ----------------

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/go-kit/kit v0.13.0
 	github.com/go-kit/log v0.2.1
-	github.com/golang/protobuf v1.5.3
 	github.com/golang/snappy v0.0.4
 	github.com/jackc/pgtype v1.14.0
 	github.com/jackc/pgx/v5 v5.4.3
@@ -13,6 +12,11 @@ require (
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/prometheus v0.46.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 )
 
 require (
@@ -37,6 +41,5 @@ require (
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/server.go
+++ b/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-kit/kit/sd"
 	"github.com/go-kit/kit/sd/lb"
 	"github.com/go-kit/log"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -248,7 +247,7 @@ func (ca *crateDbPrometheusAdapter) handleRead(w http.ResponseWriter, r *http.Re
 	}
 
 	var req prompb.ReadRequest
-	if err := proto.Unmarshal(reqBuf, &req); err != nil {
+	if err := req.Unmarshal(reqBuf); err != nil {
 		level.Error(logger).Log("msg", "Failed to unmarshal body", "err", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -271,7 +270,7 @@ func (ca *crateDbPrometheusAdapter) handleRead(w http.ResponseWriter, r *http.Re
 			{Timeseries: result},
 		},
 	}
-	data, err := proto.Marshal(&resp)
+	data, err := resp.Marshal()
 	if err != nil {
 		level.Error(logger).Log("msg", "Failed to marshal response", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -333,7 +332,7 @@ func (ca *crateDbPrometheusAdapter) handleWrite(w http.ResponseWriter, r *http.R
 	}
 
 	var req prompb.WriteRequest
-	if err := proto.Unmarshal(reqBuf, &req); err != nil {
+	if err := req.Unmarshal(reqBuf); err != nil {
 		level.Error(logger).Log("msg", "Failed to unmarshal body", "err", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## About

Update to `google.golang.org/protobuf 1.31`. See also:
- GH-62

