### PR TITLE
Add integration tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,13 @@
 
 version: 2
 updates:
+
   - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     name: "Go ${{ matrix.go-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         go-version: [ 1.20.x, 1.21.x ]
-      fail-fast: true
 
     steps:
       - name: Acquire sources
@@ -44,6 +44,13 @@ jobs:
         run: |
           ./devtools/check-gofmt
 
-      - name: Invoke tests
+      - name: Unit tests
         run: |
           go test -v
+
+      - name: Integration tests
+        if: runner.os == 'Linux'
+        run: |
+          docker compose --file tests/docker-compose.yaml up --detach
+          pip install -r requirements-test.txt
+          pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,16 @@
 name: Tests
 
 on:
+  pull_request: ~
   push:
     branches: [ main ]
-  pull_request: ~
 
   # Allow job to be triggered manually.
   workflow_dispatch:
+
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 .idea
+.venv
 build
 cratedb-prometheus-adapter
+__pycache__
+*.pyc

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -64,16 +64,26 @@ Run CrateDB and Prometheus::
 
     docker compose --file tests/docker-compose.yaml up
 
+Set up Python sandbox::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements-test.txt
+
 Run integration tests::
 
     pytest
 
-Run services in background (FYI)::
+Ad hoc deployment
+=================
 
-    # Start.
+You can also use the Docker Compose service definition to run both CrateDB
+and Prometheus in the background, by using DC's ``--detach`` option::
+
     docker compose --file tests/docker-compose.yaml up --detach
 
-    # Inspect logs.
+Then, for inspecting the log output of the background services, use this command::
+
     docker compose --file tests/docker-compose.yaml logs --follow
 
 Maintaining dependencies

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -42,10 +42,39 @@ To build the ``cratedb-prometheus-adapter`` executable, run::
 
    go build
 
+Unit tests
+==========
+
 To run the test suite, execute::
 
-   go test -v
+    go test -v
 
+For running the linter, invoke::
+
+    gofmt -l -d .
+
+To format the files, according to what the linter says, run::
+
+    gofmt -w .
+
+Integration tests
+=================
+
+Run CrateDB and Prometheus::
+
+    docker compose --file tests/docker-compose.yaml up
+
+Run integration tests::
+
+    pytest
+
+Run services in background (FYI)::
+
+    # Start.
+    docker compose --file tests/docker-compose.yaml up --detach
+
+    # Inspect logs.
+    docker compose --file tests/docker-compose.yaml logs --follow
 
 Maintaining dependencies
 ========================
@@ -121,10 +150,15 @@ from.
 To expose the ``/read``, ``/write`` and ``/metrics`` endpoints, the port
 ``9268`` must be published::
 
-   docker run --rm -ti -p 9268:9268 crate/cratedb-prometheus-adapter
+   docker run --rm -it \
+   --publish=9268:9268 \
+   crate/cratedb-prometheus-adapter
 
 Since the default configuration would use ``localhost`` as CrateDB endpoint, a
 ``config.yml`` with the correct configuration needs to be mounted on
 ``/etc/cratedb-prometheus-adapter/config.yml``::
 
-   docker run --rm -ti -p 9268:9268 -v $(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml crate/cratedb-prometheus-adapter
+   docker run --rm -it \
+   --publish=9268:9268 --volume=$(pwd)/config.yml:/etc/cratedb-prometheus-adapter/config.yaml \
+   crate/cratedb-prometheus-adapter
+

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ variants. You can choose freely which fits your needs best.
 Usage
 =====
 
-Create the following table in your CrateDB database:
+Create the following table in your CrateDB database using `ddl.sql`_:
 
 .. code-block:: sql
 
@@ -63,6 +63,10 @@ default configuration. More details how to individually configure it are
 outlined within the next section.
 
 To display all available command line options and flags, use the ``-h`` flag.
+
+In order to inquire the ``/metrics`` HTTP endpoint, use an HTTP client like ``curl``::
+
+    curl localhost:9268/metrics
 
 CrateDB adapter endpoint configuration
 ======================================
@@ -200,6 +204,7 @@ start the service, and enable it to be started automatically on system boot::
 .. _config.yml: https://github.com/crate/cratedb-prometheus-adapter/blob/main/config.yml
 .. _cratedb-prometheus-adapter.default: https://github.com/crate/cratedb-prometheus-adapter/blob/main/systemd/cratedb-prometheus-adapter.default
 .. _cratedb-prometheus-adapter.service: https://github.com/crate/cratedb-prometheus-adapter/blob/main/systemd/cratedb-prometheus-adapter.service
+.. _ddl.sql: https://github.com/crate/cratedb-prometheus-adapter/blob/main/sql/ddl.sql
 .. _Query Timeouts - Using Context Cancellation: https://www.sohamkamani.com/golang/sql-database/#query-timeouts---using-context-cancellation
 .. _remote read: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read
 .. _remote write: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

--- a/crate.go
+++ b/crate.go
@@ -227,7 +227,7 @@ func (c crateEndpoint) read(ctx context.Context, r *crateReadRequest) (*crateRea
 	// pgx4 implements query timeouts using context cancellation.
 	// See `write` function for more details.
 	ctx, _ = context.WithTimeout(ctx, c.readTimeout)
-	rows, err := c.readPool.Query(ctx, r.stmt, nil)
+	rows, err := c.readPool.Query(ctx, r.stmt)
 	if err != nil {
 		return nil, fmt.Errorf("error executing read request query: %v", err)
 	}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.isort]
+profile = "black"
+
+[tool.black]
+line-length = 100
+
+[tool.pytest.ini_options]
+minversion = "2.0"
+addopts = """
+  -rfEX -p pytester --strict-markers --verbosity=3
+  """
+env = [
+    "CRATEDB_CONNECTION_STRING=crate://crate@localhost/?ssl=false",
+    "CRATEDB_PROMETHEUS_ADAPTER_METRICS_URL=http://localhost:9268/metrics",
+    "PROMETHEUS_URL=http://localhost:9090/",
+]
+
+log_level = "DEBUG"
+log_cli_level = "DEBUG"
+
+testpaths = [
+    "tests",
+]
+xfail_strict = true
+markers = [
+]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+crash
+cratedb-toolkit==0.0.2
+pueblo[proc]==0.0.4
+prometheus-api-client<0.6
+pytest<8
+pytest-env<2
+requests<3

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "metrics" (
+    "timestamp" TIMESTAMP,
+    "labels_hash" STRING,
+    "labels" OBJECT(DYNAMIC),
+    "value" DOUBLE,
+    "valueRaw" LONG,
+    "day__generated" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', "timestamp"),
+    PRIMARY KEY ("timestamp", "labels_hash", "day__generated")
+) PARTITIONED BY ("day__generated");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,95 @@
+import os
+import shlex
+import subprocess
+import time
+
+import pytest
+from cratedb_toolkit.util import DatabaseAdapter
+from prometheus_api_client import PrometheusConnect
+from pueblo.util.proc import process
+
+
+@pytest.fixture
+def adapter_metrics():
+    """
+    The list of metric names exported by CrateDB Prometheus Adapter.
+    """
+    return [
+        "cratedb_prometheus_adapter_read_crate_failed_total",
+        "cratedb_prometheus_adapter_read_crate_latency_seconds_bucket",
+        "cratedb_prometheus_adapter_read_crate_latency_seconds_sum",
+        "cratedb_prometheus_adapter_read_crate_latency_seconds_count",
+        "cratedb_prometheus_adapter_read_failed_total",
+        "cratedb_prometheus_adapter_read_latency_seconds_bucket",
+        "cratedb_prometheus_adapter_read_latency_seconds_sum",
+        "cratedb_prometheus_adapter_read_latency_seconds_count",
+        "cratedb_prometheus_adapter_read_timeseries_samples_sum",
+        "cratedb_prometheus_adapter_read_timeseries_samples_count",
+        "cratedb_prometheus_adapter_write_crate_failed_total",
+        "cratedb_prometheus_adapter_write_crate_latency_seconds_bucket",
+        "cratedb_prometheus_adapter_write_failed_total",
+        "cratedb_prometheus_adapter_write_latency_seconds_bucket",
+        "cratedb_prometheus_adapter_write_latency_seconds_sum",
+        "cratedb_prometheus_adapter_write_latency_seconds_count",
+        "cratedb_prometheus_adapter_write_timeseries_samples_sum",
+        "cratedb_prometheus_adapter_write_timeseries_samples_count",
+    ]
+
+
+@pytest.fixture(scope="session")
+def reset_database(cratedb_client):
+    """
+    Create a blank canvas `metrics` database table.
+    """
+    cratedb_client.run_sql("DROP TABLE IF EXISTS metrics;")
+    cratedb_client.run_sql(open("sql/ddl.sql").read())
+
+
+@pytest.fixture(scope="session")
+def flush_database(cratedb_client):
+    """
+    Let the data converge between background daemons, and flush the database.
+    """
+
+    def flush():
+        time.sleep(1)
+        cratedb_client.run_sql("REFRESH TABLE metrics;")
+
+    return flush
+
+
+@pytest.fixture(scope="session")
+def cratedb_client():
+    """
+    Provide a database client to the test cases.
+    """
+    return DatabaseAdapter(dburi=os.environ["CRATEDB_CONNECTION_STRING"])
+
+
+@pytest.fixture(scope="session")
+def prometheus_client():
+    """
+    Provide a Prometheus client to the test cases.
+    """
+    return PrometheusConnect(url=os.environ["PROMETHEUS_URL"], disable_ssl=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cratedb_prometheus_adapter(reset_database, cratedb_client, flush_database):
+    """
+    Start the CrateDB Prometheus Adapter.
+    """
+
+    command = "go run ."
+    with process(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as daemon:
+        # Give the server time to start.
+        time.sleep(2)
+
+        # Check if the server started successfully.
+        assert not daemon.poll(), daemon.stdout.read().decode("utf-8")
+        time.sleep(1)
+
+        # Let the adapter collect a few metrics.
+        flush_database()
+
+        yield daemon

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: '3.0'
+
+services:
+
+  cratedb:
+    image: crate/crate:nightly
+    ports:
+      - "4200:4200/tcp"
+      - "5432:5432/tcp"
+
+    # Make `host.docker.internal` work on Linux.
+    # https://stackoverflow.com/a/67158212
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  prometheus:
+    image: prom/prometheus:main
+    ports:
+      - "9090:9090/tcp"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+    # Make `host.docker.internal` work on Linux.
+    # https://stackoverflow.com/a/67158212
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  cratedb-version:
+    image: crate/crate:nightly
+    command: -version
+
+  prometheus-version:
+    image: prom/prometheus:main
+    command: --version

--- a/tests/prometheus.yml
+++ b/tests/prometheus.yml
@@ -1,0 +1,75 @@
+global:
+  # By default, scrape targets every 15 seconds.
+  scrape_interval: 15s
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    subsystem: 'database'
+
+# Scrape configurations for two endpoints: It scrapes metrics from both
+# Prometheus, and from CrateDB Prometheus Adapter.
+
+# The job name will be added as a label `job=<job_name>` to any
+# time-series scraped from the corresponding configuration item.
+
+# `scrape_interval` overrides the global default scrape interval for
+# individual targets. For testing purposes, this value is tuned down
+# to permit fast metrics convergence.
+scrape_configs:
+
+  - job_name: 'prometheus'
+    scrape_interval: 250ms
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'cratedb'
+    scrape_interval: 250ms
+    static_configs:
+      - targets: ['host.docker.internal:9268']
+
+remote_write:
+
+  # The URL of the endpoint to send samples to.
+
+  # When Prometheus is running on Docker, and the Prometheus adapter on localhost.
+  - url: http://host.docker.internal:9268/write
+
+  # When the Prometheus adapter is also running on Docker.
+  #- url: http://cratedb-prometheus-adapter:9268/write
+
+  # When the Prometheus adapter is running on localhost.
+  #- url: http://localhost:9268/write
+
+    # Timeout for requests to the remote write endpoint.
+    remote_timeout: 2s
+
+    # Configure the sending of series metadata to remote storage.
+    metadata_config:
+      # Configure how frequently metric metadata is sent to remote storage.
+      send_interval: 5ms
+
+    # Configure the queue used to write to remote storage.
+    # For testing purposes, the deadline value is tuned down to avoid buffering.
+    queue_config:
+      # Maximum time a sample will wait in buffer.
+      batch_send_deadline: 1ms
+      # Minimum and maximum number of shards, i.e. amount of concurrency.
+      min_shards: 1
+      max_shards: 1
+      # Initial and maximum retry delay. `min` gets doubled for every retry.
+      min_backoff: 1ms
+      max_backoff: 1ms
+
+remote_read:
+  # When Prometheus is running on Docker, and the Prometheus adapter on localhost.
+  - url: http://host.docker.internal:9268/read
+
+  # When the Prometheus adapter is also running on Docker.
+  #- url: http://cratedb-prometheus-adapter:9268/read
+
+  # When the Prometheus adapter is running on localhost.
+  #- url: http://localhost:9268/read
+
+    # Timeout for requests to the remote read endpoint.
+    remote_timeout: 2s

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,132 @@
+import os
+import time
+from pprint import pprint
+from unittest import mock
+
+import pytest
+import requests
+
+
+def test_exported_metrics_http(adapter_metrics):
+    """
+    Verify the names of the metrics exported by CrateDB Prometheus Adapter.
+    Here, the CrateDB Prometheus Adapter is queried using HTTP.
+    """
+    response = requests.get(os.environ["CRATEDB_PROMETHEUS_ADAPTER_METRICS_URL"])
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/plain")
+
+    payload = response.text
+    for attribute in adapter_metrics:
+        assert attribute in payload
+
+
+def test_all_metrics(prometheus_client, adapter_metrics):
+    """
+    Verify the list of all the metrics that Prometheus scrapes includes the adapter metrics.
+    """
+    metrics = sorted(prometheus_client.all_metrics())
+
+    # Verify if all the metrics of the adapter are present.
+    for attribute in adapter_metrics:
+        assert attribute in metrics
+
+
+def test_custom_query(prometheus_client):
+    """
+    Probe the `custom_query` method.
+    """
+
+    value = prometheus_client.custom_query(
+        query="sum(cratedb_prometheus_adapter_read_crate_failed_total)"
+    )
+    assert len(value) == 1
+    timestamp = mock.ANY
+    total_sum = "0"
+    assert value[0] == {"metric": {}, "value": [timestamp, total_sum]}
+
+
+def test_get_metric_aggregation_success(prometheus_client):
+    """
+    Probe an aggregation inquiry.
+    """
+    result = prometheus_client.get_metric_aggregation(
+        "cratedb_prometheus_adapter_read_crate_failed_total", operations=["max"]
+    )
+    assert result["max"] == 0
+
+
+def test_get_metric_aggregation_unknown_metric(prometheus_client):
+    """
+    Probe inquiring an aggregation on an unknown metric.
+    """
+    result = prometheus_client.get_metric_aggregation("foobar", operations=["max"])
+    assert result is None
+
+
+def test_get_metric_aggregation_unknown_operation(prometheus_client):
+    """
+    Probe inquiring an aggregation using an unknown operation.
+    """
+    with pytest.raises(TypeError) as ex:
+        prometheus_client.get_metric_aggregation(
+            "cratedb_prometheus_adapter_write_timeseries_samples_count", operations=["unknown"]
+        )
+    assert ex.match("Invalid operation: unknown")
+
+
+def test_verify_no_failures(prometheus_client):
+    """
+    Verify no failures happened by inspecting corresponding metrics.
+    """
+    failed_total_attributes = [
+        "cratedb_prometheus_adapter_read_crate_failed_total",
+        "cratedb_prometheus_adapter_read_failed_total",
+        "cratedb_prometheus_adapter_write_crate_failed_total",
+        "cratedb_prometheus_adapter_write_failed_total",
+    ]
+    for failed_total_attribute in failed_total_attributes:
+        result = prometheus_client.get_metric_aggregation(
+            failed_total_attribute, operations=["sum"]
+        )
+        assert result == {"sum": 0.0}
+
+
+def test_verify_write_activity(prometheus_client):
+    """
+    Verify the write-path works well.
+    """
+    result = prometheus_client.get_current_metric_value(
+        metric_name="cratedb_prometheus_adapter_write_timeseries_samples_sum"
+    )
+    value = int(result[0]["value"][1])
+    assert value > 1_000
+
+
+def test_verify_read_activity(prometheus_client, flush_database, cratedb_client):
+    """
+    Verify the read-path works well.
+    """
+
+    # 1. Submit a few read requests.
+    query_metrics = [
+        "cratedb_prometheus_adapter_write_latency_seconds_count",
+        "cratedb_prometheus_adapter_write_latency_seconds_bucket",
+        "cratedb_prometheus_adapter_read_failed_total",
+        "cratedb_prometheus_adapter_write_failed_total",
+        "prometheus_http_requests_total",
+        "up",
+    ]
+    for metric in query_metrics:
+        prometheus_client.custom_query(query=metric)
+
+    # Wait for telemetry data to settle.
+    flush_database()
+
+    # 2. Verify data arrived in database.
+    result = prometheus_client.get_current_metric_value(
+        metric_name="cratedb_prometheus_adapter_read_timeseries_samples_sum"
+    )
+    pprint(result)
+    value = int(result[0]["value"][1])
+    assert value >= 6

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -1,0 +1,154 @@
+import datetime as dt
+from pprint import pprint
+from unittest import mock
+
+import pandas as pd
+from prometheus_api_client import MetricRangeDataFrame, MetricSnapshotDataFrame
+
+
+def test_all_metrics(prometheus_client):
+    """
+    Probe the list of all the metrics that the Prometheus host scrapes.
+    """
+    metrics = sorted(prometheus_client.all_metrics())
+    pprint(metrics)
+    assert len(metrics) > 250
+    assert "go_gc_duration_seconds" in metrics
+    assert "up" in metrics
+
+
+def test_get_value_success(prometheus_client):
+    """
+    Probe the `get_current_metric_value` method.
+    """
+    value = prometheus_client.get_current_metric_value(
+        metric_name="up", label_config={"job": "prometheus"}
+    )
+    assert value == [
+        {
+            "metric": {"__name__": "up", "instance": "localhost:9090", "job": "prometheus"},
+            "value": [mock.ANY, "1"],
+        }
+    ]
+
+    value = prometheus_client.get_current_metric_value(
+        metric_name="up", label_config={"job": "cratedb"}
+    )
+    assert value == [
+        {
+            "metric": {"__name__": "up", "instance": "host.docker.internal:9268", "job": "cratedb"},
+            "value": [mock.ANY, "1"],
+        }
+    ]
+
+
+def test_get_value_unknown_metric(prometheus_client):
+    """
+    Probe the `get_current_metric_value` method with an unknown metric.
+    """
+    value = prometheus_client.get_current_metric_value(
+        metric_name="unknown", label_config={"job": "prometheus"}
+    )
+    assert value == []
+
+
+def test_get_value_unknown_label(prometheus_client):
+    """
+    Probe the `get_current_metric_value` method with an unknown label constraint.
+    """
+
+    value = prometheus_client.get_current_metric_value(
+        metric_name="up", label_config={"job": "unknown"}
+    )
+    assert value == []
+
+
+def test_get_value_any(prometheus_client):
+    """
+    Without any constraint, verify querying a common metric is included into _two_ series.
+    """
+    value = prometheus_client.get_current_metric_value(metric_name="up")
+    assert len(value) == 2
+
+
+def test_custom_query(prometheus_client):
+    """
+    Probe the `custom_query` method.
+    """
+
+    # Here, we are fetching the values of a particular metric name
+    value = prometheus_client.custom_query(query="prometheus_http_requests_total")
+    assert len(value) > 2
+    assert value[0] == {
+        "metric": {
+            "__name__": "prometheus_http_requests_total",
+            "code": "200",
+            "handler": "/",
+            "instance": "localhost:9090",
+            "job": "prometheus",
+        },
+        "value": [mock.ANY, "0"],
+    }
+
+    # Now, lets try to fetch the `sum` of the metrics
+    value = prometheus_client.custom_query(query="sum(prometheus_http_requests_total)")
+    assert len(value) == 1
+    timestamp = mock.ANY
+    total_sum = mock.ANY
+    assert value[0] == {"metric": {}, "value": [timestamp, total_sum]}
+
+
+def test_query_dataframe_snapshot(prometheus_client):
+    """
+    Probe the `get_current_metric_value` method, together with `MetricSnapshotDataFrame`.
+    """
+
+    metric_data = prometheus_client.get_current_metric_value(metric_name="up")
+    metric_df = MetricSnapshotDataFrame(metric_data)
+    assert isinstance(metric_df, pd.DataFrame)
+    assert list(metric_df.columns) == ["__name__", "instance", "job", "timestamp", "value"]
+    assert metric_df.index.name is None
+    assert isinstance(metric_df.index[0], int)
+
+
+def test_query_dataframe_timerange(prometheus_client):
+    """
+    Probe the `get_metric_range_data` method, together with `MetricRangeDataFrame`.
+    """
+
+    metric_data = prometheus_client.get_metric_range_data(
+        metric_name="up",
+        start_time=(dt.datetime.now() - dt.timedelta(minutes=30)),
+        end_time=dt.datetime.now(),
+    )
+    metric_df = MetricRangeDataFrame(metric_data)
+    assert isinstance(metric_df, pd.DataFrame)
+    assert list(metric_df.columns) == ["__name__", "instance", "job", "value"]
+    assert metric_df.index.name == "timestamp"
+    assert isinstance(metric_df.index[0], pd.Timestamp)
+
+
+def test_query_timerange_future(prometheus_client):
+    """
+    When querying data from the future, the result is empty.
+    """
+
+    metric_data = prometheus_client.get_metric_range_data(
+        metric_name="up",
+        start_time=dt.datetime.now() + dt.timedelta(minutes=5),
+        end_time=dt.datetime.now() + dt.timedelta(minutes=10),
+    )
+    assert metric_data == []
+
+
+def test_query_timerange_past(prometheus_client):
+    """
+    When querying data from the near past, the result is empty.
+    """
+
+    metric_data = prometheus_client.get_metric_range_data(
+        metric_name="up",
+        start_time=dt.datetime.now() - dt.timedelta(days=1095),
+        end_time=dt.datetime.now() - dt.timedelta(days=365),
+    )
+    assert metric_data == []


### PR DESCRIPTION
## About

As we learned through GH-88, the unit tests are not sufficient to validate the code base thoroughly. This patch intends to bring in integration tests with real instances of Prometheus, CrateDB, and CrateDB Prometheus Adapter, effectively adding end-to-end test cases, so that corresponding required adjustments/fixes like GH-96 or 2043818d will not be missed in the future.

## Details

The patch also includes the commit 2043818d20, which is actual a bugfix accompanying GH-96. It has been discovered while adding the test cases validating the read path.

## Screenshot

![image](https://github.com/crate/cratedb-prometheus-adapter/assets/453543/646fd9ea-43ea-410f-aa2d-22aee77b85cd)

## Outlook

The integration tests added on behalf of this patch will ensure that bringing in those upcoming dependency update patches will not break the application again.

- GH-98
- GH-102
- GH-103
- GH-108

/cc @matriv, @seut, @ckurze, @wierdvanderhaar 
