### PR TITLE
CI: Fix broken build by using most recent Golang version (1.21)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
+.pytest_cache
+.venv
 build
+cratedb-prometheus-adapter

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,25 @@
+# Stage builds through GitHub Actions (GHA).
+name: Builds
+
+on:
+  pull_request: ~
+  push:
+    branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+  # Run builds each night.
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Run release job
+        run: ./devtools/release.sh

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -5,15 +5,19 @@
 # https://github.com/crazy-max/ghaction-docker-meta
 # https://github.com/docker/build-push-action
 # https://github.com/MarcelCoding/luna/blob/main/.github/workflows/ci.yaml
-name: Release
+name: OCI
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
   push:
     tags:
       - '*.*.*'
+
+  # Allow job to be triggered manually.
   workflow_dispatch:
+
+  # Build nightlies.
+  schedule:
+    - cron: '0 5 * * *'
 
 env:
   GHCR_IMAGE_NAME: crate/cratedb-prometheus-adapter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.21 as builder
 WORKDIR /go/src/github.com/crate/cratedb-prometheus-adapter
 COPY . /go/src/github.com/crate/cratedb-prometheus-adapter/
 RUN CGO_ENABLED=0 GOOS=linux go build

--- a/devtools/release.Dockerfile
+++ b/devtools/release.Dockerfile
@@ -3,7 +3,7 @@
 # Run release archive builder within Docker container.
 #
 
-FROM golang:1.16
+FROM golang:1.21
 
 RUN apt-get update && apt-get --yes install zip
 

--- a/devtools/release.sh
+++ b/devtools/release.sh
@@ -11,7 +11,7 @@ rm build/*
 NAME="cratedb-prometheus-adapter"
 
 # Use most recent git tag as version number.
-# TODO: Should this be made more elaborate?
+# TODO: Should this be made more elaborate, to also account for patch and nightly releases?
 VERSION="$(git tag | tail -n1)"
 
 # Build program for multiple architectures.


### PR DESCRIPTION
## About

While OCI images for 0.5.0 have been released, the binary program builds failed. This patch resolves GH-111, and adds a corresponding GHA CI workflow to ensure they don't break again unnoticed.
