### PR TITLE
CI: Start building binaries for the ARM architecture

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - name: Run release job
+      - name: Run build job
         run: ./devtools/release.sh

--- a/devtools/release_build.sh
+++ b/devtools/release_build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Build release archives for Linux, Darwin and Windows.
+# Build release archives for Linux, Darwin, and Windows.
 #
 
-# Compute package base name
+# Compute package names.
 if [[ -z "${NAME}" ]]; then
   echo "ERROR: Unable to determine package name"
   exit 1
@@ -24,36 +24,39 @@ fi
 BASE_FILENAME="${NAME}-${SUFFIX}"
 
 
-# Build program for multiple platforms
+# Utility functions.
 
-export GOOS=linux
-export GOARCH=386
-FILENAME="${BASE_FILENAME}.${GOOS}.${GOARCH}.tar.gz"
-echo "Building ${FILENAME}"
-go build
-tar -cvzf ${FILENAME} ${NAME}
-rm ${NAME}
+function build_tarball() {
+  os=$1
+  arch=$2
+  filename="${BASE_FILENAME}.${os}.${arch}.tar.gz"
+  echo "Building ${filename}"
+  go build
+  tar -cvzf ${filename} ${NAME}
+  rm ${NAME}
+}
 
-export GOOS=linux
-export GOARCH=amd64
-FILENAME="${BASE_FILENAME}.${GOOS}.${GOARCH}.tar.gz"
-echo "Building ${FILENAME}"
-go build
-tar -cvzf ${FILENAME} ${NAME}
-rm ${NAME}
+function build_windows_zipball() {
+  os=$1
+  arch=$2
+  filename="${BASE_FILENAME}.${os}.${arch}.zip"
+  echo "Building ${filename}"
+  go build -o ${NAME}.exe
+  zip ${filename} ${NAME}.exe
+  rm ${NAME}.exe
+}
 
-export GOOS=darwin
-export GOARCH=amd64
-FILENAME="${BASE_FILENAME}.${GOOS}.${GOARCH}.tar.gz"
-echo "Building ${FILENAME}"
-go build
-tar -cvzf ${FILENAME} ${NAME}
-rm ${NAME}
 
-export GOOS=windows
-export GOARCH=amd64
-FILENAME="${BASE_FILENAME}.${GOOS}.${GOARCH}.zip"
-echo "Building ${FILENAME}"
-go build -o ${NAME}.exe
-zip ${FILENAME} ${NAME}.exe
-rm ${NAME}.exe
+# Build program for multiple platforms.
+function main() {
+  build_tarball linux amd64
+  build_tarball linux arm64
+  build_tarball linux 386
+  build_tarball linux arm
+  build_tarball darwin amd64
+  build_tarball darwin arm64
+  build_windows_zipball windows amd64
+  build_windows_zipball windows arm64
+}
+
+main


### PR DESCRIPTION
## About

Add build slots for ARMv8 (64-bit) for all of Linux, Darwin, and Windows. Also add ARMv7 (32-bit) for Linux.
