### PR TITLE
CI: Start providing OCI images for the ARM architecture

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -82,6 +82,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -8,6 +8,8 @@
 name: OCI
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     tags:
       - '*.*.*'


### PR DESCRIPTION
## About

Following the spirit of GH-113, this patch also adds the ARM architecture to OCI builds. OCI images are Linux-only so far.
