### PR TITLE
Packaging: Re-add compatibility with glibc 2.31

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 
+- Packaging: Re-add compatibility with glibc 2.31,
+  by building on ``golang:1.20-bullseye``.
+
+
 2024-01-12 0.5.0
 ================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.20-bullseye as builder
 WORKDIR /go/src/github.com/crate/cratedb-prometheus-adapter
 COPY . /go/src/github.com/crate/cratedb-prometheus-adapter/
 RUN CGO_ENABLED=0 GOOS=linux go build

--- a/devtools/release.Dockerfile
+++ b/devtools/release.Dockerfile
@@ -3,7 +3,7 @@
 # Run release archive builder within Docker container.
 #
 
-FROM golang:1.21
+FROM golang:1.20-bullseye
 
 RUN apt-get update && apt-get --yes install zip
 


### PR DESCRIPTION
## About

By building on `golang:1.20-bullseye`, the program will be compatible with glibc >=2.31 again, thus resolving GH-121.
