### PR TITLE
Ignore samples with different values with same timestamp on ingest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 
+- Changed the behavior to ignore samples with identical timestamps but different
+  values during ingestion. This change aligns with Prometheus' behavior, as
+  duplicates should not occur. However, since this enforcement is recent,
+  there may be setups with existing duplicates; thus, we now ignore them to
+  prevent errors.
 
 2024-01-23 0.5.1
 ================

--- a/crate.go
+++ b/crate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const crateWriteStatement = `INSERT INTO metrics ("labels", "labels_hash", "timestamp", "value", "valueRaw") VALUES ($1, $2, $3, $4, $5)`
+const crateWriteStatement = `INSERT INTO metrics ("labels", "labels_hash", "timestamp", "value", "valueRaw") VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
 
 type crateRow struct {
 	labels     model.Metric
@@ -112,10 +112,9 @@ func newCrateEndpoint(ep *endpointConfig) *crateEndpoint {
 }
 
 func (c *crateEndpoint) endpoint() endpoint.Endpoint {
-	/**
-	 * Initialize connection pools lazily here instead of in `newCrateEndpoint()`,
-	 * so that the adapter does not crash on startup if the endpoint is unavailable.
-	**/
+
+	// Initialize connection pools lazily here instead of in `newCrateEndpoint()`,
+	// so that the adapter does not crash on startup if the endpoint is unavailable.
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 
 		// Initialize database connection pools.
@@ -134,9 +133,8 @@ func (c *crateEndpoint) endpoint() endpoint.Endpoint {
 }
 
 func (c *crateEndpoint) createPools(ctx context.Context) (err error) {
-	/**
-	 * Initialize two connection pools, one for read/write each.
-	**/
+
+	// Initialize two connection pools, one for read/write each.
 	c.readPool, err = createPoolWithPoolSize(ctx, c.poolConf.Copy(), c.readPoolSize)
 	if c.readPool == nil {
 		c.readPool, err = createPoolWithPoolSize(ctx, c.poolConf.Copy(), c.readPoolSize)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Considering that Prometheus doesn't allow samples with same timestamp and different values and enforcing this more strictly with newer version, just adding a `ON CONFLICT DO NOTHING` should be sufficient.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cratedb-prometheus-adapter/issues/135
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
