### PR TITLE
chore: remove creation of new pool on every request which can lead to potential memory leak

### DIFF
--- a/crate.go
+++ b/crate.go
@@ -135,7 +135,6 @@ func (c *crateEndpoint) endpoint() endpoint.Endpoint {
 func (c *crateEndpoint) createPools(ctx context.Context) (err error) {
 
 	// Initialize two connection pools, one for read/write each.
-	c.readPool, err = createPoolWithPoolSize(ctx, c.poolConf.Copy(), c.readPoolSize)
 	if c.readPool == nil {
 		c.readPool, err = createPoolWithPoolSize(ctx, c.poolConf.Copy(), c.readPoolSize)
 		if err != nil {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Investigating this issue https://github.com/crate/cratedb-prometheus-adapter/issues/176, I found that the connection pool is created on every request, and the previous pool is not explicitly closed.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes https://github.com/crate/cratedb-prometheus-adapter/issues/176
