### PR TITLE
OCI: Update images to use Golang 1.24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ 1.21.x, 1.22.x, 1.23.x]
+        go-version: [
+          1.21.x,
+          1.22.x,
+          1.23.x,
+          1.24.x,
+        ]
 
     steps:
       - name: Acquire sources

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES for CrateDB Prometheus Adapter
 Unreleased
 ==========
 - Updated `prometheus/common` from 0.62.0 to 0.63.0
+- OCI: Updated images to use Golang 1.24
 
 2025-03-05 0.5.4
 ================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS builder
+FROM golang:1.24-bullseye AS builder
 WORKDIR /go/src/github.com/crate/cratedb-prometheus-adapter
 COPY . /go/src/github.com/crate/cratedb-prometheus-adapter/
 RUN CGO_ENABLED=0 GOOS=linux go build

--- a/devtools/release.Dockerfile
+++ b/devtools/release.Dockerfile
@@ -3,7 +3,7 @@
 # Run release archive builder within Docker container.
 #
 
-FROM golang:1.23-bullseye
+FROM golang:1.24-bullseye
 
 RUN apt-get update && apt-get --yes install zip
 


### PR DESCRIPTION
## About

Use [Golang 1.24](https://go.dev/doc/go1.24) across the board.

go1.24.0 has been released on 2025-02-11.
go1.24.1 has been released on 2025-03-04.
