### PR TITLE
Runtime: Deprecate support for Go 1.21 and 1.22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         go-version: [
-          1.21.x,
-          1.22.x,
           1.23.x,
           1.24.x,
           1.25.x,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 ==========
 
 - Runtime: Updated to Go 1.25, OCI now uses Debian 13 "trixie"
+- Runtime: Deprecated support for Go 1.21 and 1.22
 
 2025-05-22 0.5.8
 ================


### PR DESCRIPTION
What the title says.