### PR TITLE
CI: Stop testing on Go 1.23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         go-version: [
-          1.23.x,
           1.24.x,
           1.25.x,
         ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crate/cratedb-prometheus-adapter
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.2
 


### PR DESCRIPTION
## Problem

Dependabot updates went south.
```go
go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
```
- https://github.com/crate/cratedb-prometheus-adapter/actions/runs/18941609614/job/54081577361?pr=261

## Solution

Let's leave Go 1.23 behind.

## References
- GH-260
- GH-261